### PR TITLE
Add persistence and status bar to diff editor

### DIFF
--- a/src/components/ThemedMonacoDiffEditor.tsx
+++ b/src/components/ThemedMonacoDiffEditor.tsx
@@ -2,7 +2,7 @@ import type { Theme } from '@a24z/industry-theme';
 import { DiffEditor, loader, DiffEditorProps, DiffOnMount } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
 import { initVimMode } from 'monaco-vim';
-import React, { useMemo, useRef, useEffect } from 'react';
+import React, { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 
 // Configure Monaco to use the locally bundled version
 loader.config({ monaco });
@@ -45,22 +45,171 @@ export interface ThemedMonacoDiffEditorProps extends Omit<DiffEditorProps, 'them
    * Enable Vim mode keybindings (only works in unified/inline view)
    */
   vimMode?: boolean;
+  /**
+   * Initial value for the original model (useful for uncontrolled usage)
+   */
+  initialValue?: string;
+  /**
+   * Initial value for the modified model when used in uncontrolled mode
+   */
+  initialModifiedValue?: string;
+  /**
+   * Callback invoked when the modified content should be saved (e.g., via Ctrl/Cmd+S)
+   */
+  onSave?: (value: string, context: { filePath?: string }) => void | Promise<void>;
+  /**
+   * Optional file path used to provide additional context to save handlers
+   */
+  filePath?: string;
+  /**
+   * Enable the Ctrl/Cmd+S save shortcut (defaults to true)
+   */
+  enableSaveShortcut?: boolean;
+  /**
+   * Optional callback notified whenever the dirty state changes
+   */
+  onDirtyChange?: (isDirty: boolean) => void;
+  /**
+   * Hide the built-in status bar (for vim mode and save indicators)
+   */
+  hideStatusBar?: boolean;
 }
 
 /**
  * A Monaco diff editor component that integrates with industry-theme
  */
-export const ThemedMonacoDiffEditor: React.FC<ThemedMonacoDiffEditorProps> = ({
-  theme,
-  loadingComponent,
-  options,
-  vimMode = false,
-  onMount,
-  ...editorProps
-}) => {
+export const ThemedMonacoDiffEditor: React.FC<ThemedMonacoDiffEditorProps> = (props) => {
+  const {
+    theme,
+    loadingComponent,
+    options,
+    vimMode = false,
+    onMount,
+    initialValue,
+    initialModifiedValue,
+    onSave,
+    filePath,
+    enableSaveShortcut = true,
+    onDirtyChange,
+    hideStatusBar = false,
+    ...restEditorProps
+  } = props;
+
+  const {
+    modified: controlledModified,
+    defaultValue,
+    onChange: externalOnChange,
+    ...forwardedEditorProps
+  } = restEditorProps;
+
+  const resolvedInitialModifiedValue = initialModifiedValue ?? initialValue;
+  const isModifiedControlled = controlledModified !== undefined;
+
+  const computeInitialModifiedValue = useCallback(() => {
+    if (resolvedInitialModifiedValue !== undefined) return resolvedInitialModifiedValue;
+    if (typeof controlledModified === 'string') return controlledModified;
+    if (typeof defaultValue === 'string') return defaultValue;
+    return '';
+  }, [controlledModified, defaultValue, resolvedInitialModifiedValue]);
+
+  const [internalModifiedValue, setInternalModifiedValue] = useState<string>(() =>
+    computeInitialModifiedValue()
+  );
+  const [savedModifiedValue, setSavedModifiedValue] = useState<string>(() =>
+    computeInitialModifiedValue()
+  );
+  const [isDirty, setIsDirty] = useState<boolean>(false);
+
   const monacoTheme = useMemo(() => getMonacoTheme(theme), [theme]);
   const vimModeRef = useRef<{ dispose: () => void } | null>(null);
   const statusNodeRef = useRef<HTMLDivElement | null>(null);
+  const changeSubscriptionRef = useRef<monaco.IDisposable | null>(null);
+  const savedValueRef = useRef<string>(savedModifiedValue);
+  const isControlledRef = useRef<boolean>(isModifiedControlled);
+  const prevFilePathRef = useRef<string | undefined>(filePath);
+  const prevInitialModifiedValueRef = useRef<string | undefined>(resolvedInitialModifiedValue);
+  const filePathRef = useRef<string | undefined>(filePath);
+  const onSaveRef = useRef<typeof onSave>(onSave);
+
+  useEffect(() => {
+    savedValueRef.current = savedModifiedValue;
+  }, [savedModifiedValue]);
+
+  useEffect(() => {
+    isControlledRef.current = isModifiedControlled;
+  }, [isModifiedControlled]);
+
+  useEffect(() => {
+    filePathRef.current = filePath;
+  }, [filePath]);
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  const currentModifiedValue = isModifiedControlled
+    ? (controlledModified as string | undefined) ?? ''
+    : internalModifiedValue;
+
+  useEffect(() => {
+    if (
+      !isModifiedControlled &&
+      resolvedInitialModifiedValue !== undefined &&
+      resolvedInitialModifiedValue !== prevInitialModifiedValueRef.current
+    ) {
+      setInternalModifiedValue(resolvedInitialModifiedValue);
+      setSavedModifiedValue(resolvedInitialModifiedValue);
+      savedValueRef.current = resolvedInitialModifiedValue;
+      setIsDirty(false);
+    }
+    prevInitialModifiedValueRef.current = resolvedInitialModifiedValue;
+  }, [isModifiedControlled, resolvedInitialModifiedValue]);
+
+  useEffect(() => {
+    if (filePath !== prevFilePathRef.current) {
+      const baseline = resolvedInitialModifiedValue ?? currentModifiedValue;
+      if (!isModifiedControlled && resolvedInitialModifiedValue !== undefined) {
+        setInternalModifiedValue(resolvedInitialModifiedValue);
+      }
+      setSavedModifiedValue(baseline);
+      savedValueRef.current = baseline;
+      setIsDirty(false);
+      prevFilePathRef.current = filePath;
+    }
+  }, [currentModifiedValue, filePath, isModifiedControlled, resolvedInitialModifiedValue]);
+
+  useEffect(() => {
+    const dirty = currentModifiedValue !== savedModifiedValue;
+    setIsDirty((prev) => (prev === dirty ? prev : dirty));
+  }, [currentModifiedValue, savedModifiedValue]);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  const syncDirtyState = useCallback((value: string) => {
+    const dirty = value !== savedValueRef.current;
+    setIsDirty((prev) => (prev === dirty ? prev : dirty));
+  }, []);
+
+  const updateSavedState = useCallback((nextSavedValue: string) => {
+    savedValueRef.current = nextSavedValue;
+    setSavedModifiedValue(nextSavedValue);
+    setIsDirty(false);
+  }, []);
+
+  type DiffOnChangeHandler = NonNullable<DiffEditorProps['onChange']>;
+  const handleChange = useCallback<DiffOnChangeHandler>(
+    (value, event) => {
+      const nextValue = value ?? '';
+      if (!isModifiedControlled) {
+        setInternalModifiedValue(nextValue);
+      }
+      syncDirtyState(nextValue);
+      externalOnChange?.(value, event);
+    },
+    [externalOnChange, isModifiedControlled, syncDirtyState]
+  );
 
   const defaultOptions: monaco.editor.IDiffEditorConstructionOptions = {
     readOnly: false,
@@ -83,17 +232,52 @@ export const ThemedMonacoDiffEditor: React.FC<ThemedMonacoDiffEditorProps> = ({
     <div style={{ color: theme.colors.textSecondary, padding: 8 }}>Loading diff editor…</div>
   );
 
-  const handleMount: DiffOnMount = (editor, monaco) => {
-    // Initialize Vim mode if enabled and in unified view
+  const handleMount: DiffOnMount = (editor, monacoInstance) => {
+    const modifiedEditor = editor.getModifiedEditor();
+
+    if (changeSubscriptionRef.current) {
+      changeSubscriptionRef.current.dispose();
+    }
+
+    changeSubscriptionRef.current = modifiedEditor.onDidChangeModelContent(() => {
+      const latestValue = modifiedEditor.getValue();
+      if (!isControlledRef.current) {
+        setInternalModifiedValue(latestValue);
+      }
+      syncDirtyState(latestValue);
+    });
+
     if (vimMode && statusNodeRef.current && mergedOptions.renderSideBySide === false) {
-      // In unified view, get the modified editor (the single visible editor)
-      const modifiedEditor = editor.getModifiedEditor();
       vimModeRef.current = initVimMode(modifiedEditor, statusNodeRef.current);
     }
 
-    // Call user's onMount handler if provided
+    if (enableSaveShortcut && onSaveRef.current) {
+      modifiedEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, async () => {
+        const saveHandler = onSaveRef.current;
+        if (!saveHandler) {
+          return;
+        }
+        const latestValue = modifiedEditor.getValue();
+        try {
+          const result = saveHandler(latestValue, { filePath: filePathRef.current });
+          if (result && typeof (result as Promise<void>).then === 'function') {
+            await result;
+          }
+          updateSavedState(latestValue);
+        } catch (error) {
+          console.error('Failed to save diff editor contents', error);
+        }
+      });
+    }
+
+    const initialEditorValue = modifiedEditor.getValue();
+    if (!isModifiedControlled) {
+      setInternalModifiedValue(initialEditorValue);
+    }
+    syncDirtyState(initialEditorValue);
+
     if (onMount) {
-      onMount(editor, monaco);
+      onMount(editor, monacoInstance);
     }
   };
 
@@ -104,11 +288,16 @@ export const ThemedMonacoDiffEditor: React.FC<ThemedMonacoDiffEditorProps> = ({
         vimModeRef.current.dispose();
         vimModeRef.current = null;
       }
+      if (changeSubscriptionRef.current) {
+        changeSubscriptionRef.current.dispose();
+        changeSubscriptionRef.current = null;
+      }
     };
   }, [vimMode]);
 
   const isUnifiedView = mergedOptions.renderSideBySide === false;
-  const showVimStatus = vimMode && isUnifiedView;
+  const canShowVimStatus = vimMode && isUnifiedView;
+  const shouldShowStatusBar = !hideStatusBar && (vimMode || onSave || !isModifiedControlled);
 
   return (
     <div style={{ position: 'relative', height: '100%' }}>
@@ -117,16 +306,21 @@ export const ThemedMonacoDiffEditor: React.FC<ThemedMonacoDiffEditorProps> = ({
         options={mergedOptions}
         loading={loading}
         onMount={handleMount}
-        {...editorProps}
+        modified={currentModifiedValue}
+        onChange={handleChange}
+        defaultValue={defaultValue}
+        {...forwardedEditorProps}
       />
-      {showVimStatus && (
+      {shouldShowStatusBar && (
         <div
-          ref={statusNodeRef}
           style={{
             position: 'absolute',
             bottom: 0,
             left: 0,
             right: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
             padding: '4px 8px',
             backgroundColor: theme.colors.backgroundSecondary,
             color: theme.colors.text,
@@ -135,7 +329,28 @@ export const ThemedMonacoDiffEditor: React.FC<ThemedMonacoDiffEditorProps> = ({
             borderTop: `1px solid ${theme.colors.border}`,
             zIndex: 1000,
           }}
-        />
+        >
+          <div style={{ flex: 1, minHeight: '1em', display: 'flex', alignItems: 'center' }}>
+            {canShowVimStatus && (
+              <div ref={statusNodeRef} style={{ flex: 1, minHeight: '1em' }} />
+            )}
+          </div>
+          <div
+            style={{
+              marginLeft: canShowVimStatus ? 'auto' : 0,
+              padding: '0 6px',
+              borderRadius: 4,
+              border: `1px solid ${isDirty ? theme.colors.warning : theme.colors.border}`,
+              backgroundColor: isDirty
+                ? theme.colors.backgroundSecondary
+                : theme.colors.background,
+              color: isDirty ? theme.colors.warning : theme.colors.textSecondary,
+              fontWeight: 600,
+            }}
+          >
+            {isDirty ? 'Unsaved changes' : 'Saved'}
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add persistence-related props to the themed diff editor and sync baseline state with file changes
- mirror single-editor dirty tracking, save shortcut registration, and Vim wiring for the modified model
- render a combined status bar that shows Vim status (when available) and a saved/unsaved indicator

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1eb74218c832187dccf9358235957